### PR TITLE
Add aggregated podcast sources page

### DIFF
--- a/content/podcast-sources.md
+++ b/content/podcast-sources.md
@@ -1,0 +1,5 @@
+---
+title: "All Episode Links"
+layout: podcast-sources
+---
+

--- a/layouts/_default/podcast-sources.html
+++ b/layouts/_default/podcast-sources.html
@@ -1,0 +1,15 @@
+{{ define "main" }}
+<article class="post-content">
+  <h1>{{ .Title }}</h1>
+  {{ range sort (where site.RegularPages "Section" "podcasts") "Date" "desc" }}
+    {{ $episode := . }}
+    {{ $src := $episode.Params.sources }}
+    {{ with $episode.Resources.GetMatch $src }}
+      <h2>{{ $episode.Date.Format "2006-01-02" }} - Episode {{ $episode.Params.episode }}</h2>
+      {{ $content := .Content | markdownify }}
+      {{ $content = $content | replaceRE "<a href=" " <a target=\"_blank\" href=" }}
+      {{ $content | safeHTML }}
+    {{ end }}
+  {{ end }}
+</article>
+{{ end }}


### PR DESCRIPTION
## Summary
- add `podcast-sources` page that aggregates all episode links
- implement `podcast-sources` layout to iterate through podcast bundles and render their sources

## Testing
- `hugo --minify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf284b53a88328a21eee846bf99055